### PR TITLE
Fixing bug with ariasForModules function

### DIFF
--- a/js/components/ada.js
+++ b/js/components/ada.js
@@ -214,7 +214,12 @@ function ariasForModules() {
 	]
 	for (i = 0; i < moduleAnchors.length || i < moduleSelfClosers.length; ++i) {
 		$j(moduleAnchors[i]).each(function () {
-			var ariaLinkLabel = "Click to view " + $j(this).text();
+			//JNOLFI: on dynamic module there is an onlick with a table blowing up the ariaLabel 
+			//JNOLFI: check for a table > return OR program what you want to do here [i.e. find a textnode in table] 
+			if ($j(this).children('table').length > 0) {
+				return;
+			}
+			var ariaLinkLabel = "Click to view " + $j.trim($j(this).text());
 			$j(this).attr({
 				'aria-label': ariaLinkLabel,
 				'title': ariaLinkLabel


### PR DESCRIPTION
@ce-joe 

Had a note come back to me from PM about the dynamic groups module showing a huge tool tip when you drag a rule/group into the tool to work on. Found the issue with ariasForModules() function (fix is on line 217 of ada.js in COMPONENTS). This fix just looks for a table as a child to the moduleAnchors array item and exits out of the function for that item (i.e. no aria label is added). I see that you have commented out that function so maybe we're moving off this item? If that's the case, please close out of this pull request and delete BUG branch.