### PR TITLE
Fixed issue with nav-link wrap on dropdown text nodes

### DIFF
--- a/js/components/bootstrapNav.js
+++ b/js/components/bootstrapNav.js
@@ -5,11 +5,12 @@ $j('.navbar-nav li').addClass('nav-item');
 $j('.navbar-nav li a').addClass('nav-link');
 $j('.navbar-nav .ulMenuItem.selectedItem').closest('.ulMenu').parent().addClass('selectedParent');
 $j('.navbar-nav .ulMenuItem.selectedParent').closest('.ulMenu').parent().addClass('selectedGrandParent');
-$j('.navbar-nav li.ulMenuItem.level1, .navbar li.ulMenuItem.level2, .navbar li.ulMenuItem.level3').each(function () {
-    $j(this).html($j.trim($j(this).html())); //trim the HTML
-    $j(this).contents().filter(function () {
-        return this.nodeType === 3 && this.nodeValue.trim().length != 0; //
-    }).wrap('<a class="nav-link" href="#"></a>');
+//JNOLFI: using .navbar selector for all [not dynamically created] and just selecting all axis nav plugin LI el [removing multiple selectors] 
+$j('.navbar li.ulMenuItem').each(function() {
+    //JNOLFI: removing this as it was causing failure on subnav $j(this).html($j.trim($j(this).html())); //trim the HTML
+    $j(this).contents().filter(function() {
+      return this.nodeType === 3 && this.nodeValue != null; // Node.TEXT_NODE
+    }).wrap('<a href="#" class="nav-link"></a>');
 });
 $j('.navbar-nav.ulMenu.level0').find('.ulMenu').addClass('dropdown-menu').attr('role', 'menu');
 $j('.dropdown-menu').parent().addClass('dropdown');


### PR DESCRIPTION
@ce-joe 

Issue:
Dropdown menu items that were just folders, were not being wrapped with the nav-link A tag.

Fix:
Kind of a weird one, but the each function in bootstrapNav.js was able to get contents and return correct nodeType and nodeValues to evaluate child nodes (i.e. all text nodes were there). First I changed parameters on filter function to look for nodeValue != null as any DOM element returned a null value but text wold show a string. When I removed the initial HTML trim of the Item's html, that seemed to fix it totally. Tested on Hampton Hall 2020 and West Vancouver Yacht Club and no longer experiencing the error. I also tightened up the selector for that function to just look for all li.ulMenuItem elements. See notes in js file on BUG branch.